### PR TITLE
retry after short delay if the tcp send() encounters an EINPROGRESS

### DIFF
--- a/tcp_transport.cc
+++ b/tcp_transport.cc
@@ -1,4 +1,5 @@
-#include "tcp_transport.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 #include <esp_log.h>
 #include <unistd.h>
 #include <cstring>
@@ -7,8 +8,9 @@
 #include <netdb.h>
 #include <string.h>
 #include <errno.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
+
+#include "tcp_transport.h"
+
 #define TAG "TcpTransport"
 
 TcpTransport::TcpTransport() : fd_(-1) {}


### PR DESCRIPTION
数据量发送比较大，或者发送调用比较频繁的时候，tcp send接口可能出现占时失败的情况，此时errno被置成EINPROGRESS， 这种情况下稍微延迟一下重试就可以继续发送，会比直接断掉连接会更好。