### PR TITLE
解决esp-idf更新到6.0后xiaozhi-esp32编译失败问题

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 dependencies:
-  idf: "^5.3"
+  idf: ">=5.3"
 description: ESP32 ML307R/ML307A Cat.1 Cellular Module
 files:
   exclude:


### PR DESCRIPTION
解决esp-idf更新到6.0后xiaozhi-esp32编译失败问题