### PR TITLE
ml307: http chunk size max 4KB

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,4 +8,4 @@ files:
 license: MIT
 repository: https://github.com/78/esp-ml307
 url: https://github.com/78/esp-ml307
-version: 3.3.3
+version: 3.3.4

--- a/src/ml307/ml307_mqtt.cc
+++ b/src/ml307/ml307_mqtt.cc
@@ -150,10 +150,7 @@ bool Ml307Mqtt::Publish(const std::string topic, const std::string payload, int 
     std::string command = "AT+MQTTPUB=" + std::to_string(mqtt_id_) + ",\"" + topic + "\",";
     command += std::to_string(qos) + ",0,0,";
     command += std::to_string(payload.size());
-    if (!at_uart_->SendCommand(command)) {
-        return false;
-    }
-    return at_uart_->SendCommand(payload);
+    return at_uart_->SendCommandWithData(command, 1000, true, payload.data(), payload.size());
 }
 
 bool Ml307Mqtt::Subscribe(const std::string topic, int qos) {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to HTTP and MQTT data transmission in the project. The main focus is on enhancing the handling of large data payloads, ensuring compatibility with chunked and non-chunked HTTP modes, and simplifying the process of sending data over AT commands.

**HTTP Transmission Improvements**
* Updated `HttpClient::Write` to properly handle both chunked and non-chunked HTTP modes, allowing direct transmission of raw data when not in chunked mode. This fixes issues where non-chunked requests could not send data. [[1]](diffhunk://#diff-ea41c8447f23fa50b323a55e9eba074d748630b6ed768312a3c97f486907b89fL596-R602) [[2]](diffhunk://#diff-ea41c8447f23fa50b323a55e9eba074d748630b6ed768312a3c97f486907b89fR617-R624)

**Large Data Handling**
* Refactored `Ml307Http::Write` to support sending large payloads by splitting data into 4KB chunks, ensuring reliable transmission for requests exceeding the previous size limit.

**AT Command Data Transmission**
* Updated `Ml307Http::Open` and `Ml307Mqtt::Publish` to use `SendCommandWithData`, streamlining the process of sending both commands and associated data in one step, improving reliability and code clarity. [[1]](diffhunk://#diff-704b57e501a38ccf0cff7c7adea0ca5400cbffcef613f59e4cf8c2db9e8e8b9aL227-R237) [[2]](diffhunk://#diff-c66b6a5dcc91e572ddb399461a42201838a02b531adc30ba575c2200fdf1a8b6L153-R153)

**Version Update**
* Bumped the component version in `idf_component.yml` from `3.3.3` to `3.3.4` to reflect these changes.