### PR TITLE
set atuart tasks to cpu0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 这是一个适用于 ML307R / EC801E / NT26K LTE Cat.1 模组的组件。
 本项目最初为 https://github.com/78/xiaozhi-esp32 项目创建。
 
+出现 UART_FIFO_OVF 需要设置 CONFIG_UART_ISR_IN_IRAM=y，其他 IO 如 LVGL 放在 CPU1
+
 ## 🆕 版本 3.0 新特性
 
 - **自动模组检测**: 自动识别 ML307 和 EC801E 模组

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,4 +8,4 @@ files:
 license: MIT
 repository: https://github.com/78/esp-ml307
 url: https://github.com/78/esp-ml307
-version: 3.3.4
+version: 3.3.5

--- a/include/at_uart.h
+++ b/include/at_uart.h
@@ -19,6 +19,10 @@
 #define AT_EVENT_DATA_AVAILABLE BIT1
 #define AT_EVENT_COMMAND_DONE   BIT2
 #define AT_EVENT_COMMAND_ERROR  BIT3
+#define AT_EVENT_BUFFER_FULL    BIT4
+#define AT_EVENT_FIFO_OVF       BIT5
+#define AT_EVENT_BREAK          BIT6
+#define AT_EVENT_UNKNOWN        BIT7
 
 // 默认配置
 #define UART_NUM                UART_NUM_1


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the UART event handling and HTTP client logic for the LTE Cat.1 module component. The main changes include enhanced event detection and handling in the UART layer, more robust HTTP response parsing, and minor documentation and configuration updates.

**UART Event Handling Improvements:**

* Added new UART event flags (`AT_EVENT_BUFFER_FULL`, `AT_EVENT_FIFO_OVF`, `AT_EVENT_BREAK`, `AT_EVENT_UNKNOWN`) in `at_uart.h` to support more granular event detection.
* Updated `EventTask` and `ReceiveTask` in `at_uart.cc` to use these new event flags, enabling better handling and logging of buffer full, FIFO overflow, and break conditions. Now, multiple events are processed and logged appropriately, improving reliability. [[1]](diffhunk://#diff-a8af2ea0d1aee2ed8e56040f140efcd52bc939c97c6a756378f29a7b48cf13e2L94-R100) [[2]](diffhunk://#diff-a8af2ea0d1aee2ed8e56040f140efcd52bc939c97c6a756378f29a7b48cf13e2L113-R112) [[3]](diffhunk://#diff-a8af2ea0d1aee2ed8e56040f140efcd52bc939c97c6a756378f29a7b48cf13e2R124-R133)

**Task Management and Performance:**

* Changed task creation from `xTaskCreate` to `xTaskCreatePinnedToCore` in `at_uart.cc`, assigned tasks to specific cores, adjusted stack sizes, and set priorities for improved performance and stability.

**HTTP Client Robustness:**

* Fixed HTTP response parsing in `ml307_http.cc` to prevent multiple EOF assignments and ensure correct chunked and non-chunked transfer handling.
* Improved HTTP read and close logic: added checks for instance activity before reading, and switched from `notify_one()` to `notify_all()` for condition variable notification to avoid missed signals when closing connections. [[1]](diffhunk://#diff-704b57e501a38ccf0cff7c7adea0ca5400cbffcef613f59e4cf8c2db9e8e8b9aR94-R96) [[2]](diffhunk://#diff-704b57e501a38ccf0cff7c7adea0ca5400cbffcef613f59e4cf8c2db9e8e8b9aL335-R340)

**Documentation and Configuration Updates:**

* Updated `README.md` to add troubleshooting advice for `UART_FIFO_OVF` and CPU usage recommendations.
* Bumped component version in `idf_component.yml` from `3.3.4` to `3.3.5`.