### PR TITLE
修复销毁 ML307 Modem 对象时 spinlock_acquire 断言失败导致设备重启

### DIFF
--- a/src/at_uart.cc
+++ b/src/at_uart.cc
@@ -28,6 +28,9 @@ AtUart::AtUart(gpio_num_t tx_pin, gpio_num_t rx_pin, gpio_num_t dtr_pin, gpio_nu
 }
 
 AtUart::~AtUart() {
+    if (receive_task_handle_) {
+        vTaskDelete(receive_task_handle_);
+    }
     if (event_task_handle_) {
         vTaskDelete(event_task_handle_);
     }


### PR DESCRIPTION
##  问题现象

  在销毁 ML307 Modem 对象后，发生 spinlock_acquire 断言失败导致设备重启：
  assert failed: spinlock_acquire spinlock.h:142 (lock->count == 0)

##  根本原因

  78__esp-ml307 库的 AtUart::~AtUart() 析构函数存在资源泄漏 bug

  在 at_uart.cc:30-53 的析构函数中：
  - ✅ 删除了 event_task_handle_
  - ❌ 遗漏了 receive_task_handle_

  // at_uart.cc 第 115 行创建了 receive_task
  xTaskCreatePinnedToCore(..., &receive_task_handle_, 0);

  // 但析构函数中只删除了 event_task_handle_，没有删除 receive_task_handle_

##  影响

  当 AtUart 对象被销毁后，receive_task 仍在运行，尝试访问已释放的资源（UART 句柄、队列等），导致 spinlock 断言失败。

##  修复

  在 managed_components/78__esp-ml307/src/at_uart.cc 的析构函数开头添加：
  if (receive_task_handle_) {
      vTaskDelete(receive_task_handle_);
  }

##  日志

```log
assert failed: spinlock_acquire spinlock.h:142 (lock->count == 0)
Core  0 register dump:
--- Stack dump detected
MEPC    : 0x4ff0dbb8  RA      : 0x4ff0d6c4  SP      : 0x4ff39c50  GP      : 0x4ff1b500  
--- 0x4ff0dbb8: panic_abort at /Users/user/Programs/esp-idf-v5.5.1/components/esp_system/panic.c:483
--- 0x4ff0d6c4: esp_vApplicationTickHook at /Users/user/Programs/esp-idf-v5.5.1/components/esp_system/freertos_hooks.c:31
TP      : 0x4ff39e50  T0      : 0x37363534  T1      : 0x7271706f  T2      : 0x33323130  
S0/FP   : 0x00000086  S1      : 0x00000001  A0      : 0x4ff39c8c  A1      : 0x4ff1f7a1  
A2      : 0x00000001  A3      : 0x00000029  A4      : 0x00000001  A5      : 0x4ff25000  
A6      : 0x00000010  A7      : 0x76757473  S2      : 0x00000009  S3      : 0x4ff39da1  
S4      : 0x4ff1f7a0  S5      : 0x0000cdcd  S6      : 0x00000001  S7      : 0x00000000  
S8      : 0x00000000  S9      : 0x00000000  S10     : 0x00000000  S11     : 0x00000000  
T3      : 0x6e6d6c6b  T4      : 0x6a696867  T5      : 0x66656463  T6      : 0x62613938  
MSTATUS : 0x00011880  MTVEC   : 0x4ff00003  MCAUSE  : 0x00000002  MTVAL   : 0x00000000  
--- 0x4ff00003: _vector_table at ??:?
MHARTID : 0x00000000  


--- Backtrace:


add symbol table from file "/Users/user/Projects/lua-esp32/build/bootloader/bootloader.elf"
panic_abort (details=details@entry=0x4ff39c8c "assert failed: spinlock_acquire spinlock.h:142 (lock->count == 0)") at /Users/user/Programs/esp-idf-v5.5.1/components/esp_system/panic.c:483
483         asm("unimp");   // should be an invalid operation on RISC-V targets
#0  panic_abort (details=details@entry=0x4ff39c8c "assert failed: spinlock_acquire spinlock.h:142 (lock->count == 0)") at /Users/user/Programs/esp-idf-v5.5.1/components/esp_system/panic.c:483
#1  0x4ff0d6c4 in esp_system_abort (details=details@entry=0x4ff39c8c "assert failed: spinlock_acquire spinlock.h:142 (lock->count == 0)") at /Users/user/Programs/esp-idf-v5.5.1/components/esp_system/port/esp_system_chip.c:87
#2  0x4ff185d0 in __assert_func (file=0x481b2638 "", line=<optimized out>, func=<optimized out>, expr=0x481b48f0 "") at /Users/user/Programs/esp-idf-v5.5.1/components/newlib/src/assert.c:80
#3  0x00000000 in ?? ()
Backtrace stopped: frame did not save the PC



ELF file SHA256: ae4244550

Rebooting...
```