### PR TITLE
Refactor WebSocket class to use member variables for message handling…

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -5,7 +5,7 @@ files:
   exclude:
   - .git
   - dist
-license: MIT
+license: Apache-2.0
 repository: https://github.com/78/esp-ml307
 url: https://github.com/78/esp-ml307
-version: 3.5.3
+version: 3.5.4

--- a/include/web_socket.h
+++ b/include/web_socket.h
@@ -4,8 +4,9 @@
 #include <functional>
 #include <string>
 #include <map>
-#include <thread>
+#include <vector>
 #include <mutex>
+#include <memory>
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
 
@@ -57,6 +58,10 @@ private:
     std::function<void(int)> on_error_;
     std::function<void()> on_connected_;
     std::function<void()> on_disconnected_;
+
+    std::vector<char> current_message_;
+    bool is_fragmented_ = false;
+    bool is_binary_ = false;
 
     void OnTcpData(const std::string& data);
     bool SendControlFrame(uint8_t opcode, const void* data, size_t len);


### PR DESCRIPTION
This pull request updates the WebSocket implementation with several improvements and bug fixes, primarily focusing on better handling of message fragmentation, thread safety, and minor protocol correctness. It also updates the component metadata.

WebSocket implementation improvements:

* Moved `current_message`, `is_fragmented`, and `is_binary` from static variables inside `OnTcpData` to member variables of the `WebSocket` class, improving thread safety and correctness for handling concurrent connections. (`include/web_socket.h`, `src/web_socket.cc`) [[1]](diffhunk://#diff-37c6bc5f7509b00c790360608ee1b60369ccda0288d82e91d6990b9e524097fdR62-R65) [[2]](diffhunk://#diff-312c571ff33fda9c9639d87e81ebd1ae948a3ffa564a5e5855ec9b4e99f0a16cL314-R315) [[3]](diffhunk://#diff-312c571ff33fda9c9639d87e81ebd1ae948a3ffa564a5e5855ec9b4e99f0a16cR351-R380)
* Fixed payload length decoding for extended payloads by properly casting to `uint64_t`, ensuring correct handling of large WebSocket frames. (`src/web_socket.cc`)
* Added a check to only copy and unmask payload data if `payload_length > 0`, preventing potential issues with zero-length frames. (`src/web_socket.cc`)
* Removed unnecessary threading for sending Pong responses (Ping frames are now handled synchronously), simplifying the code. (`src/web_socket.cc`)

Component metadata updates:

* Changed the license to Apache-2.0 and bumped the version to 3.5.4 in `idf_component.yml`.… and improve data processing logic.