### PR TITLE
Use uart-uhci component (DMA)

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,6 @@
 dependencies:
-  idf: '>=5.3'
+  idf: '>=5.5.2'
+  78/uart-uhci: ~0.1.0
 description: ESP32 ML307 / EC801E / NT26K Cat.1 Cellular Module
 files:
   exclude:
@@ -8,4 +9,4 @@ files:
 license: Apache-2.0
 repository: https://github.com/78/esp-ml307
 url: https://github.com/78/esp-ml307
-version: 3.5.4
+version: 3.6.0


### PR DESCRIPTION
This pull request introduces major improvements to the UART handling in the ESP32 ML307 module by replacing the traditional UART driver with a DMA-based solution using the `uart_uhci` component. This change enhances data reception efficiency and reliability, especially for high-throughput scenarios. The update also removes legacy event handling code and streamlines buffer management.

Key changes include:

**DMA-Based UART Handling and Buffer Management:**

* Integrated the `uart_uhci` DMA controller into `AtUart`, replacing the standard UART driver for RX/TX operations. This includes initializing UHCI, setting up DMA RX buffers, and handling buffer pools for efficient data transfer. (`include/at_uart.h`, `src/at_uart.cc`) [[1]](diffhunk://#diff-a568027c9464e7bcd98b7f079090f9d594856e46fd431c16f8009bd974b21ff7R20-R35) [[2]](diffhunk://#diff-a8af2ea0d1aee2ed8e56040f140efcd52bc939c97c6a756378f29a7b48cf13e2R81-R127)
* Added a DMA RX callback (`DmaRxCallback`) to process incoming data in ISR context and queue it for task-based handling, ensuring safe and efficient data flow. (`include/at_uart.h`, `src/at_uart.cc`) [[1]](diffhunk://#diff-a568027c9464e7bcd98b7f079090f9d594856e46fd431c16f8009bd974b21ff7L126-R139) [[2]](diffhunk://#diff-a8af2ea0d1aee2ed8e56040f140efcd52bc939c97c6a756378f29a7b48cf13e2L122-L171)
* Updated the `ReceiveTask` to process data from the DMA RX queue, appending received chunks to the main RX buffer and returning buffers to the pool. (`src/at_uart.cc`)

**Code Cleanup and Legacy Removal:**

* Removed the legacy UART event task and associated event handling code, as DMA and event groups now handle data availability and interrupts. (`include/at_uart.h`, `src/at_uart.cc`) [[1]](diffhunk://#diff-a568027c9464e7bcd98b7f079090f9d594856e46fd431c16f8009bd974b21ff7R116-R121) [[2]](diffhunk://#diff-a8af2ea0d1aee2ed8e56040f140efcd52bc939c97c6a756378f29a7b48cf13e2L108-L113)

**Component and Dependency Updates:**

* Updated the `idf_component.yml` to require ESP-IDF >=5.5.2 and added a dependency on the `78/uart-uhci` component, reflecting the new DMA-based architecture. (`idf_component.yml`)
* Bumped the component version to `3.6.0` to indicate a significant update. (`idf_component.yml`)

**Transmit Path Update:**

* Modified the `SendData` method to use UHCI DMA for transmitting data instead of the standard UART driver. (`src/at_uart.cc`)