### PR TITLE
[fix]修复WebSocket 握手存在竞态

### DIFF
--- a/src/web_socket.cc
+++ b/src/web_socket.cc
@@ -148,14 +148,15 @@ bool WebSocket::Connect(const char* uri) {
     }
     request += "\r\n";
 
-    // 清除事件位（回调尚未注册，不会有新事件写入）
+    // 清除事件位
     xEventGroupClearBits(handshake_event_group_, HANDSHAKE_SUCCESS_BIT | HANDSHAKE_FAILED_BIT);
 
-    // 注册回调后再发送，避免响应在回调注册前到达被丢弃
+    // 设置数据接收回调来处理握手和后续的WebSocket帧
     tcp_->OnStream([this](const std::string& data) {
         this->OnTcpData(data);
     });
 
+    // 设置断开连接回调
     tcp_->OnDisconnected([this]() {
         if (connected_) {
             connected_ = false;

--- a/src/web_socket.cc
+++ b/src/web_socket.cc
@@ -148,20 +148,14 @@ bool WebSocket::Connect(const char* uri) {
     }
     request += "\r\n";
 
-    if (tcp_->Send(request) < 0) {
-        ESP_LOGE(TAG, "Failed to send WebSocket handshake request");
-        return false;
-    }
-
-    // 清除事件位
+    // 清除事件位（回调尚未注册，不会有新事件写入）
     xEventGroupClearBits(handshake_event_group_, HANDSHAKE_SUCCESS_BIT | HANDSHAKE_FAILED_BIT);
-    
-    // 设置数据接收回调来处理握手和后续的WebSocket帧
+
+    // 注册回调后再发送，避免响应在回调注册前到达被丢弃
     tcp_->OnStream([this](const std::string& data) {
         this->OnTcpData(data);
     });
 
-    // 设置断开连接回调
     tcp_->OnDisconnected([this]() {
         if (connected_) {
             connected_ = false;
@@ -170,6 +164,11 @@ bool WebSocket::Connect(const char* uri) {
             }
         }
     });
+
+    if (tcp_->Send(request) < 0) {
+        ESP_LOGE(TAG, "Failed to send WebSocket handshake request");
+        return false;
+    }
 
     // 等待握手完成，超时时间10秒
     EventBits_t bits = xEventGroupWaitBits(


### PR DESCRIPTION
## 问题
固件在使用websocket进行交互的时候，偶现出现卡顿的问题，抓包发现客户端回复了0 zero窗口
<img width="607" height="72" alt="image" src="https://github.com/user-attachments/assets/ee4aa49d-b24e-4598-8642-48a7da4b45bb" />
## 原因
WebSocket 握手存在竞态：`OnStream` 回调在 `tcp_->Send()` **之后**才注册。

`ReceiveTask` 在 `tcp_->Connect()` 返回时就已在后台运行。HTTP GET 发出后，若服务端响应足够快，`ReceiveTask` 会在 `stream_callback_` 注册前就收到 HTTP 101，数据被静默丢弃，握手永远无法完成。

```
调用线程                              ReceiveTask（后台运行）
    │
    ├─ tcp_->Connect() 返回
    │  ReceiveTask 已在 recv() 中阻塞等待
    │
    ├─ tcp_->Send(HTTP GET)
    │                                  服务端回复 HTTP 101
    │                                  recv() 返回，拿到 101 数据
    │                                  stream_callback_ == null → 数据丢弃
    │
    ├─ tcp_->OnStream(回调注册)        ← 太晚了，101 已经丢了
    ├─ xEventGroupWaitBits()           ← 永远等不到，直到服务端超时重传
```

## 修复

调整 `Connect()` 中的执行顺序：先清除事件位，再注册回调，最后发送。

```cpp
xEventGroupClearBits(...);   // 回调未注册，不会有新事件写入，清除安全
tcp_->OnStream(...);         // 回调就绪，之后收到的任何数据都不会丢失
tcp_->OnDisconnected(...);
tcp_->Send(request);         // 最后发送，响应必然能被回调处理
```

## 改动文件

- `src/web_socket.cc`：调整执行顺序为 `xEventGroupClearBits` → `OnStream` → `OnDisconnected` → `tcp_->Send()`
